### PR TITLE
Html refactor

### DIFF
--- a/docs/routes/templates/page.html
+++ b/docs/routes/templates/page.html
@@ -34,11 +34,11 @@
           <div style="margin: 42px 0px;">
             <div class="mc-font-title-large" style="margin-bottom: 8px;">Dynamically computing HTML</div>
             <mc-switch checked="${page.showFirst}" onchange="page.showFirst.value = this.checked" label-right="Switch HTML"></mc-switch>
-            ${html(() => (
-            page.showFirst.value ?
-            html`<div>First</div>` :
-            html`<div>Second</div>`
-            ))}
+            ${html(() => {
+              return page.showFirst.value ?
+                html`<div>First</div>` :
+                html`<div>Second</div>`;
+            })}
           </div>
         
           <div style="margin: 42px 0px;">

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 import Route from './src/client/Route.js';
 import Component from './src/client/Component.js';
 import { Signal, SignalObject, Compute, effect } from './src/client/signal.js'
-import { html, setSecurityLevel } from './src/client/html.js'
+import { html } from './src/client/html.js';
+import { setSecurityLevel } from './src/client/sanitize.js';
 import { i18n } from './src/client/i18n.js';
 import { Fetcher } from './src/client/fetcher.js';
 

--- a/src/client/Component.js
+++ b/src/client/Component.js
@@ -1,6 +1,5 @@
-import { html, watchSignals, destroySignalCache } from './html.js';
 import { getSearchParameters, getUrlParameters } from './router.js';
-import { beginTemplating, endTemplating } from './signal.js';
+import { html, activateComponent, deactivateComponent } from './html.js';
 
 
 const dashCaseRegex = /-([a-z])/g;
@@ -165,17 +164,12 @@ export default class Component extends HTMLElement {
 
     this.beforeRender();
 
-    if (this.constructor._isPage) {
-      destroySignalCache();
-      this.style.display = 'contents';
-      beginTemplating();
-    }
+    if (this.constructor._isPage) this.style.display = 'contents';
+
+    activateComponent(this);
     if (this.constructor.useShadowRoot) this.shadowRoot.appendChild(this.template());
     else this.appendChild(this.template());
-    if (this.constructor._isPage) {
-      endTemplating();
-      watchSignals();
-    }
+    deactivateComponent();
 
     this.afterRender();
   }

--- a/src/client/html.js
+++ b/src/client/html.js
@@ -1,155 +1,156 @@
-import { isSignal, Compute } from './signal.js';
+import { isSignal, Compute, beginTemplating, endTemplating, HTMLCOMPUTE } from './signal.js';
+import { sanitizeNode } from './sanitize.js';
 
-const HTMLCOMPUTE = Symbol('HTMLCOMPUTE');
-const htmlComputeString = '#htmlcompute#';
-const htmlComputeComment = `<!--${htmlComputeString}-->`;
-const attrString = '###';
-const signalString = '#signal#';
-const signalComment = `<!--${signalString}-->`;
-const subTemplateString = '#template#';
-const subTemplateComment = `<!--${subTemplateString}-->`;
-const tagRegex = new RegExp(`<\\w+([^<>]*${signalComment}[^<\\/>]*)+\\/?>`, 'g');
-const attrRegex = new RegExp(`(?:(\\s+[^\\s\\/>"=]+)\\s*=\\s*"([\\w\\s]*${signalComment}[\\w\\s]*)")|(\\s*${signalComment}\\s*)`, 'g');
-const signalCommentRegex = new RegExp(signalComment, 'g');
-const twoSpaceRegex = /\s\s/g;
-const attrPlaceholderRegex = new RegExp(attrString, 'g');
+
+// const HTMLCOMPUTE = Symbol('HTMLCOMPUTE');
 const insideCommentRegex = /<!--(?![.\s\S]*-->)/;
-const templateCache = new Map();
-const signalCache = new WeakMap();
-const signalsToWatch = new Set();
-const securityLevels = [0, 1, 2];
-let securityLevel = 1;
-const securityLevelMeta = document.querySelector('meta[name=lisecuritylevel]');
-if (securityLevelMeta) setSecurityLevel(parseInt(securityLevelMeta.getAttribute('content')));
-
-let devWarnings = false;
-const devWarningsMeta = document.querySelector('meta[name=lidevwarnings]');
-if (devWarningsMeta) devWarnings = true;
-
-const dangerousNodes = ['SCRIPT', 'IFRAME', 'NOSCRIPT', 'OBJECT', 'APPLET', 'EMBBED', 'FRAMESET'];
-const dangerousAttributesLevel1 = ['onload', 'onerror'];
-let dangerousTagRegex = new RegExp(dangerousNodes.join('|'));
-let dangerousAttributeRegex = new RegExp(dangerousAttributesLevel1.join('|'));
-const dangerousAttributeValueRegex = /javascript:|eval\(|alert|document.cookie|document\[['|"]cookie['|"]\]|&\#\d/gi;
+const twoSpaceRegex = /\s\s/g;
+const attrString = '###';
+const attrPlaceholderRegex = new RegExp(attrString, 'g');
+const computeCommentPrefix = 'lcomp_';
+const subTemplateCommentPrefix = 'lsubtemp_';
+const signalCommentPrefix = 'lsig_';
+const signalCommentRegexValue = '<!--lsig_\\d+-->';
+const signalCommentRegex = new RegExp(signalCommentRegexValue, 'g');
+const tagRegex = new RegExp(`<\\w+([^<>]*${signalCommentRegexValue}[^<\\/>]*)+\\/?>`, 'g');
+const attrRegex = new RegExp(`(?:(\\s+[^\\s\\/>"=]+)\\s*=\\s*"([\\w\\s]*${signalCommentRegexValue}[\\w\\s]*)")|(\\s*${signalCommentRegexValue}\\s*)`, 'g');
 
 
-export function setSecurityLevel(level = 1) {
-  if (!securityLevels.includes(level)) throw Error('Invalid security level. Valid values [0,1,2]')
-  securityLevel = level;
+let isObserving = false;
+let currentComponent;
+let signalCache = new Map();
+let signalsToWatch = new Set();
+let refCount = 0;
+let signalNodeRef = new Map();
+let compActiveNodesRef = new Map();
+let attrExpressionRef = new Map();
+let componentSigRef = new Map();
+
+
+let removeObserver = new MutationObserver((mutations) => {
+  for (const mutation of mutations) {
+    if (mutation.type === 'childList' && mutation.removedNodes.length > 0) {
+      if (mutation.removedNodes.length) cleanupComponents();
+    }
+  }
+});
+
+export function activateComponent(component) {
+  if (currentComponent === component) return;
+
+  if (componentSigRef.has(component)) cleanupComponents();
+  componentSigRef.set(component, new Set());
+  refCount += 1;
+
+  if (!isObserving) {
+    removeObserver.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+    isObserving = true;
+  }
+
+  currentComponent = component;
+  beginTemplating();
 }
 
-export function setDangerousTagRegex(tagNames = []) {
-  dangerousTagRegex = new RegExp(tagNames.map(v => v.toUpperCase()).join('|'));
+export function deactivateComponent() {
+  currentComponent = undefined;
+  cleanupComponents()
+  endTemplating();
 }
 
-export function setDangerousAttributes(attributeNames = []) {
-  dangerousAttributeRegex = new RegExp(attributeNames.join('|'));
+export function cleanupComponents() {
+  let i = 0;
+  for (let comp of componentSigRef) {
+    if (!comp[0].isConnected || comp[1].size === 0) {
+      destroy(comp[0]);
+      i += 1;
+    }
+  }
+
+  refCount -= i;
+  if (refCount < 0) {
+    console.log('refCount less than 0', refCount);
+    refCount = 0;
+  }
+  if (refCount === 0) disconnectObserver();
+}
+
+function destroy(component) {
+  for (let sig of componentSigRef.get(component)) {
+    if (signalNodeRef.has(sig.id)) {
+      for (let node of signalNodeRef.get(sig.id)) {
+        if (attrExpressionRef.has(node)) attrExpressionRef.delete(node);
+      }
+      signalNodeRef.get(sig.id)?.clear();
+      signalNodeRef.delete(sig.id);
+    }
+
+    if (compActiveNodesRef.has(sig.id)) {
+      compActiveNodesRef.get(sig.id)?.clear();
+      compActiveNodesRef.delete(sig.id);
+    }
+  }
+  componentSigRef.get(component).clear();
+  componentSigRef.delete(component);
+  signalCache.clear();
 }
 
 
 export function html(strings, ...args) {
-  if (typeof strings === 'function') return htmlCompute(strings);
+  if (typeof strings === 'function') return new Compute(strings, true);
+
   args.reverse();
 
-  const signals = [];
+  let arg;
+  let signals = [];
   const subClonedNodes = [];
   let template = '';
   let i = 0;
   for (; i < strings.length - 1; i++) {
     template = template + strings[i];
-    const arg = args.pop();
+    arg = args.pop();
 
     // replace commented out expression
     if (template.match(insideCommentRegex)) {
       template += '\${commented expression}';
-
-
     } else if (isSignal(arg)) {
       signals.push(arg);
-      if (!signalCache.has(arg)) {
-        signalCache.set(arg, []);
+
+      if (!signalCache.has(arg.id)) {
+        componentSigRef.get(currentComponent).add(arg);
+
+        signalCache.set(arg.id, arg);
         signalsToWatch.add(arg);
       }
 
-      if (arg[HTMLCOMPUTE] === true) template += htmlComputeComment;
-      else template += signalComment;
-
-
+      if (arg[HTMLCOMPUTE] === true) template += `<!--${computeCommentPrefix}${arg.id}-->`;
+      else template += `<!--${signalCommentPrefix}${arg.id}-->`;
     } else if (Array.isArray(arg) ? arg[0] instanceof DocumentFragment : arg instanceof DocumentFragment) {
       subClonedNodes.push([].concat(arg));
-      template += subTemplateComment;
+      template += `<!--${subTemplateCommentPrefix}-->`;
     } else {
       template += escape(arg);
     }
   }
   template += strings[i];
 
-  if (!templateCache.has(template)) templateCache.set(template, buildTemplateElement(template));
-  return prepareTemplateElement(templateCache.get(template), signals, subClonedNodes);
+  queueMicrotask(() => watch());
+  return buildTemplateElement(template, signals, subClonedNodes);
 }
 globalThis.html = html;
 
-function htmlCompute(callback) {
-  const compute = new Compute(callback);
-  compute[HTMLCOMPUTE] = true;
-  return compute;
-}
-
-export function watchSignals() {
-  queueMicrotask(() => {
-    for (const sig of signalsToWatch) {
-      sig.watch(signalChange);
-    }
-  });
-}
-
-// called from component
-export function destroySignalCache() {
-  templateCache.clear();
-
-  for (const sig of signalsToWatch) {
-    sig.unwatch(signalChange);
-  }
-  signalsToWatch.clear();
-}
 
 
-
-function signalChange(signal) {
-  const signalItems = signalCache.get(signal);
-  if (!signalItems) return;
-
-  for (const item of signalItems) {
-    if (item[0].nodeType === Node.ATTRIBUTE_NODE) {
-      let i = 0;
-      item[0].value = item[1].replace(attrString, function () {
-        return item[2][i++].valueUntracked;
-      });
-
-    } else if (signal[HTMLCOMPUTE] === true) {
-      for (const node of item[1]) {
-        node.remove();
-      }
-
-      item[1] = [];
-      if (signal.error) {
-        console.error(signal.error);
-      } else {
-        for (const frag of [].concat(signal.valueUntracked)) {
-          item[1].push(...frag.childNodes);
-          item[0].parentElement.insertBefore(frag, item[0]);
-        }
-      }
-    } else {
-      item[0].textContent = signal.valueUntracked;
-    }
-  }
-}
-
-function buildTemplateElement(template) {
+function buildTemplateElement(template, args, subClonedNodes) {
+  args.reverse();
+  subClonedNodes.reverse();
   template = adjustTemplateForAttributes(template);
+
   const templateElement = document.createElement('template');
   templateElement.innerHTML = template;
+
   const nodes = document.createNodeIterator(
     templateElement.content,
     NodeFilter.SHOW_ALL
@@ -158,104 +159,74 @@ function buildTemplateElement(template) {
   let node = nodes.nextNode();
   while (node = nodes.nextNode()) {
     switch (node.nodeType) {
+      // swap out placeholder for textNode to hold sig value
+      case Node.COMMENT_NODE:
+        if (node.data.startsWith(signalCommentPrefix)) {
+          let sig = args.pop();
+          if (!signalNodeRef.has(sig.id)) signalNodeRef.set(sig.id, new Set());
+          const textNode = document.createTextNode(sig.valueUntracked);
+          node.parentElement.replaceChild(textNode, node);
+          signalNodeRef.get(sig.id).add(textNode);
+          
+        } else if (node.data === subTemplateCommentPrefix) {
+          for (const frag of subClonedNodes.pop()) {
+            node.parentElement.insertBefore(frag, node);
+          }
+
+        } else if (node.data.startsWith(computeCommentPrefix)) {
+          let compute = args.pop();
+          if (!signalNodeRef.has(compute.id)) signalNodeRef.set(compute.id, new Set());
+          if (!compActiveNodesRef.has(compute.id)) compActiveNodesRef.set(compute.id, new Set()); 
+          for (const frag of [].concat(compute.valueUntracked)) {
+            for (let child of frag.childNodes) {
+              compActiveNodesRef.get(compute.id).add(child);
+            }
+            node.parentElement.insertBefore(frag, node);
+          }
+          signalNodeRef.get(compute.id).add(node);
+        }
+        break;
+
       case Node.ELEMENT_NODE:
         sanitizeNode(node);
-        break;
 
-      case Node.COMMENT_NODE:
-        if (node.data === signalString) {
-          const textNode = document.createTextNode(signalString);
-          node.parentElement.replaceChild(textNode, node);
-        }
-        break;
-    }
-  }
-
-  return templateElement;
-}
-
-function adjustTemplateForAttributes(template) {
-  return template.replace(tagRegex, function (all) {
-    let attrNameCounter = 0; // ensures unique attr names <div ${page.disabled ? 'disabled' : ''}
-    return all
-      .replace(attrRegex, function (attr, _name, _value, expr) {
-        if (expr) return attr.replace(signalCommentRegex, attrString + attrNameCounter++)
-        return attr.replace(signalCommentRegex, attrString);
-      }).replace(twoSpaceRegex, ' ');
-  });
-}
-
-function prepareTemplateElement(templateElement, args, subClonedNodes) {
-  args.reverse();
-  subClonedNodes.reverse();
-  const clonedNode = templateElement.content.cloneNode(true);
-  const nodes = document.createNodeIterator(
-    clonedNode,
-    NodeFilter.SHOW_ALL
-  );
-
-  let node = nodes.nextNode(); // first element is body. We do not want this
-  while (node = nodes.nextNode()) {
-    switch (node.nodeType) {
-      case Node.COMMENT_NODE:
-      case Node.TEXT_NODE:
-        switch (node.textContent) {
-          case subTemplateString:
-            for (const frag of subClonedNodes.pop()) {
-              node.parentElement.insertBefore(frag, node);
-            }
-            break;
-
-          case htmlComputeString:
-            const compute = args.pop();
-            const activeNodes = [];
-            for (const frag of [].concat(compute.valueUntracked)) {
-              activeNodes.push(...frag.childNodes);
-              node.parentElement.insertBefore(frag, node);
-            }
-            signalCache.get(compute).push([node, activeNodes]);
-            break;
-
-          case signalString:
-            const signal = args.pop();
-            node.textContent = signal.valueUntracked;
-            signalCache.get(signal).push([node]);
-            break;
-        }
-        break;
-
-      case Node.ELEMENT_NODE:
         let toRemove = []
         let toAdd = []
         let i = 0;
-
         for (; i < node.attributes.length; i++) {
-          const attr = node.attributes[i];
+          let attr = node.attributes[i];
           if (attr.value.includes(attrString)) {
-            const signals = new Set();
-            const expressions = [];
-            const templateValue = attr.value;
+            let signals = new Set();
+            let expressions = [];
+            let templateValue = attr.value;
 
             attr.value = templateValue.replace(attrPlaceholderRegex, function () {
-              const arg = args.pop();
-              expressions.push(arg)
+              let arg = args.pop();
               if (isSignal(arg)) {
                 signals.add(arg);
+                expressions.push(arg.id);
                 return arg.valueUntracked;
               }
+
+              expressions.push(arg);
               return arg;
             });
 
+
+            if (!attrExpressionRef.has(attr)) attrExpressionRef.set(attr, []);
             for (const sig of signals) {
-              signalCache.get(sig).push([attr, templateValue, expressions]);
+              if (!signalNodeRef.has(sig.id)) signalNodeRef.set(sig.id, new Set());
+              if (!signalNodeRef.get(sig.id).has(attr)) signalNodeRef.get(sig.id).add(attr);
+              attrExpressionRef.get(attr).push([sig.id, templateValue, expressions]);
             }
             signals.clear();
+            signals = undefined;
 
 
             // handle expression attr <div ${this.var}>
             // TODO handle signals?
           } else if (attr.name.includes(attrString)) {
-            const expressionValue = args.pop();
+            let expressionValue = args.pop();
             toAdd.push(document.createAttribute(expressionValue));
             toRemove.push(node.attributes[i]);
           }
@@ -269,87 +240,89 @@ function prepareTemplateElement(templateElement, args, subClonedNodes) {
 
         toAdd = undefined;
         toRemove = undefined;
+        break;
     }
   }
-  return clonedNode;
+  
+  return templateElement.content;
 }
 
 
+function adjustTemplateForAttributes(template) {
+  return template.replace(tagRegex, function (all) {
+    let attrNameCounter = 0; // ensures unique attr names <div ${page.disabled ? 'disabled' : ''}
+    return all
+      .replace(attrRegex, function (attr, _name, _value, expr) {
+        if (expr) return attr.replace(signalCommentRegex, attrString + attrNameCounter++)
+        return attr.replace(signalCommentRegex, attrString);
+      }).replace(twoSpaceRegex, ' ');
+  });
+}
 
-/**
- * Escaped content not wrapped in html template tag ${`anything`}
- *   The sanitizeNode method will handle xss
- */
 const escapeElement = document.createElement('p');
 function escape(str) {
   escapeElement.textContent = str;
   return escapeElement.innerHTML;
 }
 
+let watchRunning = false;
+function watch() {
+  if (watchRunning) return;
+  watchRunning = true;
+  queueMicrotask(() => {
+    for (const sig of signalsToWatch) {
+      sig.watch(signalChange);
+    }
+    signalsToWatch.clear();
+    watchRunning = false;
+  });
+}
 
-/**
- * Provide basic protection from XSS
- *   This is meant as a safety net. This should not be relied on to prevent attacks.
- * 
- * TODO replace with HTML Sanitizer API when available. Currently still in working spec
- */
-function sanitizeNode(node) {
-  let sanitized = false;
 
-  if (dangerousTagRegex.test(node.nodeName)) {
-    if (securityLevel === 0) {
-      if (devWarnings === true) console.warn(`Template sanitizer (WARNING): Potentially dangerous node NOT removed because of current level (${securityLevel}) "${node.nodeName}"`);
+let observerCheckRunning = false;
+function disconnectObserver() {
+  if (observerCheckRunning) return;
+  observerCheckRunning = true;
+  queueMicrotask(() => {
+    if (componentSigRef.size === 0) {
+      removeObserver.disconnect();
+      isObserving = false;
+    }
+    observerCheckRunning = false;
+  });
+}
+
+
+function signalChange(signal) {
+  let nodes = signalNodeRef.get(signal.id);
+  if (!nodes) return;
+
+  for (let node of nodes) {
+    if (node.nodeType === Node.ATTRIBUTE_NODE) {
+      let i = 0;
+      let expressions = attrExpressionRef.get(node).find(v => v[0] === signal.id);
+      node.value = expressions[1].replace(attrString, function () {
+        return signalCache.get(expressions[2][i++]).valueUntracked;
+      });
+
+    } else if (signal[HTMLCOMPUTE] === true) {
+      for (let node of compActiveNodesRef.get(signal.id)) {
+        node.remove();
+      }
+
+      compActiveNodesRef.get(signal.id).clear();
+      if (signal.error) {
+        console.error(signal.error);
+      } else {
+        for (let frag of [].concat(signal.valueUntracked)) {
+          for (let child of frag.childNodes) {
+            compActiveNodesRef.get(signal.id).add(child);
+          }
+          node.parentElement.insertBefore(frag, node);
+        }
+      }
     } else {
-      if (devWarnings === true) console.warn(`Template sanitizer (INFO): A ${node.nodeName} tag was removed because of security level (${securityLevel})`);
-      node.remove();
-      sanitized = true;
+      node.textContent = signal.valueUntracked;
     }
   }
-
-  const attributes = node.attributes;
-  for (const attr of attributes) {
-    if (sanitizeAttribute(attr) === true) sanitized = true;
-  }
-
-  return sanitized;
-}
-
-function sanitizeAttribute(attr) {
-  const nameSanitized = sanitizeAttributeName(attr.name, attr.value);
-  const valueSanitized = sanitizeAttributeValue(attr.name, attr.value);
-  if (nameSanitized || valueSanitized) {
-    if (devWarnings === true) console.warn(`Template sanitizer (INFO): Attribute removed "${attr.name}: ${attr.value}"`);
-    attr.ownerElement.removeAttribute(attr.name);
-    return true;
-  }
-  return false;
-}
-
-function sanitizeAttributeName(name, value) {
-  let shouldRemoveLevel2 = false;
-  let shouldRemoveLevel1 = false;
-
-  if (name.startsWith('on')) shouldRemoveLevel2 = true;
-  if (dangerousAttributeRegex.test(name)) shouldRemoveLevel1 = true;
-
-  if (
-    devWarnings === true &&
-    (securityLevel === 1 && shouldRemoveLevel2 && !shouldRemoveLevel1)
-    || (devWarnings === true && securityLevel === 0 && (!shouldRemoveLevel2 || !shouldRemoveLevel1))
-  ) {
-    console.warn(`Template sanitizer (WARNING): Potentially dangerous attribute NOT removed because of current level (${securityLevel}) "${name}: ${value}"`);
-  }
-  return (shouldRemoveLevel1 && securityLevel > 0) || (shouldRemoveLevel2 && securityLevel === 2);
-}
-
-const spaceRegex = /\s+/g;
-function sanitizeAttributeValue(name, value) {
-  value = value.replace(spaceRegex, '').toLowerCase();
-  if (value.match(dangerousAttributeValueRegex) !== null) {
-    if (devWarnings === true && securityLevel === 0) {
-      console.warn(`Template sanitizer (WARNING): Potentially dangerous attribute NOT removed because of current level (${securityLevel}) "${name}: ${value}"`);
-    } else return true;
-  }
-
-  return false;
 }

--- a/src/client/sanitize.js
+++ b/src/client/sanitize.js
@@ -1,0 +1,105 @@
+const securityLevels = [0, 1, 2];
+let securityLevel = 1;
+const securityLevelMeta = document.querySelector('meta[name=lisecuritylevel]');
+if (securityLevelMeta) setSecurityLevel(parseInt(securityLevelMeta.getAttribute('content')));
+
+let devWarnings = false;
+const devWarningsMeta = document.querySelector('meta[name=lidevwarnings]');
+if (devWarningsMeta) devWarnings = true;
+
+const dangerousNodes = ['SCRIPT', 'IFRAME', 'NOSCRIPT', 'OBJECT', 'APPLET', 'EMBBED', 'FRAMESET'];
+const dangerousAttributesLevel1 = ['onload', 'onerror'];
+let dangerousTagRegex = new RegExp(dangerousNodes.join('|'));
+let dangerousAttributeRegex = new RegExp(dangerousAttributesLevel1.join('|'));
+const dangerousAttributeValueRegex = /javascript:|eval\(|alert|document.cookie|document\[['|"]cookie['|"]\]|&\#\d/gi;
+const attrAppValueRegex = /^(?:page\.|this\.)/;
+
+
+
+
+export function setSecurityLevel(level = 1) {
+  if (!securityLevels.includes(level)) throw Error('Invalid security level. Valid values [0,1,2]')
+  securityLevel = level;
+}
+
+export function setDangerousTagRegex(tagNames = []) {
+  dangerousTagRegex = new RegExp(tagNames.map(v => v.toUpperCase()).join('|'));
+}
+
+export function setDangerousAttributes(attributeNames = []) {
+  dangerousAttributeRegex = new RegExp(attributeNames.join('|'));
+}
+
+
+
+/**
+ * Provide basic protection from XSS
+ *   This is meant as a safety net. This should not be relied on to prevent attacks.
+ * 
+ * TODO replace with HTML Sanitizer API when available. Currently still in working spec
+ */
+export function sanitizeNode(node) {
+  let sanitized = false;
+
+  if (dangerousTagRegex.test(node.nodeName)) {
+    if (securityLevel === 0) {
+      if (devWarnings === true) console.warn(`Template sanitizer (WARNING): Potentially dangerous node NOT removed because of current level (${securityLevel}) "${node.nodeName}"`);
+    } else {
+      if (devWarnings === true) console.warn(`Template sanitizer (INFO): A ${node.nodeName} tag was removed because of security level (${securityLevel})`);
+      node.remove();
+      sanitized = true;
+    }
+  }
+
+  const attributes = node.attributes;
+  for (const attr of attributes) {
+    if (sanitizeAttribute(attr) === true) sanitized = true;
+  }
+
+  return sanitized;
+}
+
+
+function sanitizeAttribute(attr) {
+  const nameSanitized = sanitizeAttributeName(attr.name, attr.value);
+  const valueSanitized = sanitizeAttributeValue(attr.name, attr.value);
+  if (nameSanitized || valueSanitized) {
+    if (devWarnings === true) console.warn(`Template sanitizer (INFO): Attribute removed "${attr.name}: ${attr.value}"`);
+    attr.ownerElement.removeAttribute(attr.name);
+    return true;
+  }
+  return false;
+}
+
+function sanitizeAttributeName(name, value) {
+  let shouldRemoveLevel2 = false;
+  let shouldRemoveLevel1 = false;
+
+  if (name.startsWith('on')) shouldRemoveLevel2 = true;
+  if (dangerousAttributeRegex.test(name)) shouldRemoveLevel1 = true;
+  
+  // TODO validate this is a good approach to filter out values accessing app code
+  const notValidAppValue = (shouldRemoveLevel2 || shouldRemoveLevel1) && !attrAppValueRegex.test(value);
+
+  if (
+    notValidAppValue &&
+    devWarnings === true &&
+    (securityLevel === 1 && shouldRemoveLevel2 && !shouldRemoveLevel1)
+    || (devWarnings === true && securityLevel === 0 && (!shouldRemoveLevel2 || !shouldRemoveLevel1))
+  ) {
+    console.warn(`Template sanitizer (WARNING): Potentially dangerous attribute NOT removed because of current level (${securityLevel}) "${name}: ${value}"`);
+  }
+  return notValidAppValue && ((shouldRemoveLevel1 && securityLevel > 0) || (shouldRemoveLevel2 && securityLevel === 2));
+}
+
+const spaceRegex = /\s+/g;
+function sanitizeAttributeValue(name, value) {
+  value = value.replace(spaceRegex, '').toLowerCase();
+  if (value.match(dangerousAttributeValueRegex) !== null) {
+    if (devWarnings === true && securityLevel === 0) {
+      console.warn(`Template sanitizer (WARNING): Potentially dangerous attribute NOT removed because of current level (${securityLevel}) "${name}: ${value}"`);
+    } else return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
- refactor html class
  - Enable non page components to use signals (works with "this")
  - Add global mutation observer to auto cleanup signals used in html on remove
  - Fix the mapping to prevent memory leak on signals not getting cleaned up
  - Remove template caching (this did not seem to add any benefits, and made it harder for signals to get garbage collected)
- Separate html sanitizer into separate file to make it easier to replace in the future
- Fix array proxy on SignalObject (before changes on the array would loose binding)
- Move HTML compute setting into signal class